### PR TITLE
BUGFIX: Remove duplicate Compile entries in Shared.csproj

### DIFF
--- a/Shared/OnlineBookLibrary.Shared.csproj
+++ b/Shared/OnlineBookLibrary.Shared.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -8,7 +8,5 @@
 
   <ItemGroup>
     <SupportedPlatform Include="browser" />
-    <Compile Include="Response\**\*.cs" />
-    <Compile Include="Enums\**\*.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Removed explicit Compile includes for CategoryEnum.cs and ApiResponse.cs from Shared.csproj to fix duplicate item error.
- Allowed SDK to implicitly include all .cs files as per default behavior.
